### PR TITLE
新增 NextAuth access token 登入 Django User token API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ COPY ./app /app
 WORKDIR /app
 EXPOSE 8000
 
+ARG GOOGLE_CLIENT_ID=""
+ARG GOOGLE_SECRET_KEY=""
+ARG FACEBOOK_CLIENT_ID=""
+ARG FACEBOOK_SECRET_KEY=""
 ARG DEV=false
 RUN python -m venv /py && \
     /py/bin/pip install --upgrade pip && \
@@ -31,8 +35,11 @@ RUN python -m venv /py && \
     chown -R django-user:django-user /vol && \
     chmod -R 755 /vol
 
-
-ENV PATH="/py/bin:$PATH"
+ENV PATH="/py/bin:$PATH" \
+    GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID \
+    GOOGLE_SECRET_KEY=$GOOGLE_SECRET_KEY \
+    FACEBOOK_CLIENT_ID=$FACEBOOK_CLIENT_ID \
+    FACEBOOK_SECRET_KEY=$FACEBOOK_SECRET_KEY
 
 USER django-user
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 build:
-	@docker build . && docker-compose build
+	@docker-compose build
 
 up:
 	@docker-compose up

--- a/app/app/settings.py
+++ b/app/app/settings.py
@@ -148,3 +148,19 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 10
 }
+
+SOCIAL_PROVIDERS = {
+    "google": {
+        "APP": {
+            "client_id": os.environ.get("GOOGLE_CLIENT_ID"),
+            "secret": os.environ.get("GOOGLE_SECRET_KEY")
+        }
+    },
+    "facebook": {
+        "VERSION": "v15.0",
+        'APP': {
+            'client_id': os.environ.get("FACEBOOK_CLIENT_ID"),
+            'secret': os.environ.get("FACEBOOK_SECRET_KEY"),
+        }
+    }
+}

--- a/app/user/providers/facebook/constants.py
+++ b/app/user/providers/facebook/constants.py
@@ -1,0 +1,15 @@
+from django.conf import settings
+
+PROVIDER_NAME = "Facebook"
+
+PROVIDER_SETTINGS = (
+    getattr(settings, "SOCIAL_PROVIDERS", {})
+    .get("facebook", {})
+)
+
+GRAPH_API_VERSION = (
+    PROVIDER_SETTINGS
+    .get("VERSION", "v15.0")
+)
+GRAPH_API_URL = "https://graph.facebook.com/" + GRAPH_API_VERSION
+GET_PROFILE_API = '/'.join([GRAPH_API_URL, 'me'])

--- a/app/user/providers/facebook/utils.py
+++ b/app/user/providers/facebook/utils.py
@@ -1,0 +1,50 @@
+from user.providers.facebook.constants import (
+    PROVIDER_SETTINGS,
+    GET_PROFILE_API,
+)
+import requests
+import hmac
+import hashlib
+
+
+def get_app_secret_key():
+    return PROVIDER_SETTINGS.get('APP', {}).get('secret', '')
+
+
+def compute_appsecret_proof(access_token):
+    # Generate an appsecret_proof parameter to secure the Graph API call
+    # see https://developers.facebook.com/docs/graph-api/securing-requests%20/
+    msg = access_token.encode("utf-8")
+    key = get_app_secret_key().encode("utf-8")
+    appsecret_proof = hmac.new(key, msg, digestmod=hashlib.sha256).hexdigest()
+    return appsecret_proof
+
+
+def get_user_profile(access_token):
+    response = requests.get(
+        GET_PROFILE_API,
+        params={
+            "fields": ",".join([
+                "id",
+                "email",
+                "first_name",
+                "last_name",
+                "middle_name",
+                "name",
+                "name_format",
+                "short_name",
+            ]),
+            "access_token": access_token,
+            "appsecret_proof": compute_appsecret_proof(access_token),
+        },
+    )
+    response.raise_for_status()
+    return response.json()
+
+
+def init_profile_to_user(user_profile):
+    return {
+        'is_superuser': False,
+        'is_staff': False,
+        'is_active': True
+    }

--- a/app/user/providers/google/constants.py
+++ b/app/user/providers/google/constants.py
@@ -1,0 +1,2 @@
+PROVIDER_NAME = "Google"
+GET_PROFILE_API = "https://www.googleapis.com/oauth2/v1/userinfo"

--- a/app/user/providers/google/utils.py
+++ b/app/user/providers/google/utils.py
@@ -1,0 +1,21 @@
+from user.providers.google.constants import (
+    GET_PROFILE_API,
+)
+import requests
+
+
+def get_user_profile(access_token):
+    request = requests.get(
+        GET_PROFILE_API,
+        params={"access_token": access_token, "alt": "json"},
+    )
+    request.raise_for_status()
+    return request.json()
+
+
+def init_profile_to_user(user_profile):
+    return {
+        'is_superuser': False,
+        'is_staff': False,
+        'is_active': True
+    }

--- a/app/user/serializers.py
+++ b/app/user/serializers.py
@@ -7,6 +7,20 @@ from django.contrib.auth import (get_user_model, authenticate)
 from django.utils.translation import gettext as _
 from rest_framework import serializers
 from core.models import Profile
+from user.providers.google.constants import (
+    PROVIDER_NAME as GOOGLE_PROVIDER_NAME
+)
+from user.providers.facebook.constants import (
+    PROVIDER_NAME as FACEBOOK_PROVIDER_NAME
+)
+from datetime import datetime
+import string
+import secrets
+
+
+def get_secret_random_string(length):
+    alphabet = string.ascii_letters + string.digits
+    return ''.join(secrets.choice(alphabet) for i in range(length))
 
 
 class ProfileSerializer(serializers.ModelSerializer):
@@ -73,3 +87,75 @@ class AuthTokenSerializer(serializers.Serializer):
         attrs['user'] = user
 
         return attrs
+
+
+class ExchangeProviderSerializer(serializers.Serializer):
+    email = serializers.EmailField(required=True)
+    provider_name = serializers.CharField(required=True)
+    access_token = serializers.CharField(required=True)
+
+    def validate(self, data):
+        super(ExchangeProviderSerializer, self).validate(data)
+        self.utils = self.load_provider_utils()
+        return data
+
+    def login_user_with_token(self):
+        user = None
+        user_profile = None
+        User = get_user_model()
+
+        try:
+            email = self.validated_data.get('email')
+            user_profile = self.utils.get_user_profile(self.validated_data.get('access_token'))
+            if email != user_profile['email']:
+                raise Exception("User Email doesn't match")
+
+            user = User.objects.get(email=email)
+        except User.DoesNotExist:
+            user, is_created = User.objects.update_or_create(
+                email=email,
+                defaults=self.utils.init_profile_to_user(user_profile)
+            )
+            user.set_password(get_secret_random_string(10))
+            user.save()
+        except Exception:
+            user = None
+            return user
+
+        if user and not user.is_active:
+            return None
+
+        user.last_login = datetime.now()
+        user.save()
+
+        return user
+
+
+class ExchangeGoogleSerializer(ExchangeProviderSerializer):
+    def load_provider_utils(self):
+        from user.providers.google import utils
+        return utils
+
+    def validate_provider_name(self, value):
+        if GOOGLE_PROVIDER_NAME == value:
+            return value
+
+        raise serializers.ValidationError("Provider Name is invalid")
+
+
+class ExchangeFacebookSerializer(ExchangeProviderSerializer):
+    def load_provider_utils(self):
+        from user.providers.facebook import utils
+        return utils
+
+    def validate_provider_name(self, value):
+        if FACEBOOK_PROVIDER_NAME == value:
+            return value
+
+        raise serializers.ValidationError("Provider Name is invalid")
+
+
+PROVIDER_SERIALIZERS = {
+    GOOGLE_PROVIDER_NAME: ExchangeGoogleSerializer,
+    FACEBOOK_PROVIDER_NAME: ExchangeFacebookSerializer
+}

--- a/app/user/urls.py
+++ b/app/user/urls.py
@@ -11,4 +11,5 @@ urlpatterns = [
     path('create/', views.CreateUserView.as_view(), name='create'),
     path('token/', views.CreateTokenView.as_view(), name='token'),
     path('me/', views.ManageUserView.as_view(), name='me'),
+    path('token/exchange', views.exchange_token, name='token_exchange'),
 ]

--- a/app/user/views.py
+++ b/app/user/views.py
@@ -3,13 +3,19 @@ Views for user API.
 '''
 
 
-from rest_framework import generics, authentication, permissions
+from rest_framework import generics, authentication, permissions, status
 from rest_framework.authtoken.views import ObtainAuthToken
 from rest_framework.settings import api_settings
+from rest_framework.decorators import (
+    api_view
+)
+from rest_framework.response import Response
+from rest_framework.authtoken.models import Token
 
 from user.serializers import (
     UserSerializer,
-    AuthTokenSerializer
+    AuthTokenSerializer,
+    PROVIDER_SERIALIZERS
 )
 
 
@@ -33,3 +39,22 @@ class ManageUserView(generics.RetrieveUpdateAPIView):
     def get_object(self):
         ''' Retrieve and return the authenticated user. '''
         return self.request.user
+
+
+@api_view(['POST'])
+def exchange_token(request):
+    try:
+        provider_name = request.data.get('provider_name')
+        serializer_class = PROVIDER_SERIALIZERS.get(provider_name)
+        serializer = serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        user = serializer.login_user_with_token()
+        if not user:
+            raise Exception("User login failure")
+
+        token, created = Token.objects.update_or_create(user=user)
+    except Exception:
+        return Response(status=status.HTTP_400_BAD_REQUEST)
+
+    return Response(data={"access": token.key})

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,13 +20,17 @@ services:
       - DB_NAME=devdb
       - DB_USER=devuser
       - DB_PASSWORD=devuser
+      - GOOGLE_CLIENT_ID=google_client_id
+      - GOOGLE_SECRET_KEY=google_secret_key
+      - FACEBOOK_CLIENT_ID=fb_client_id
+      - FACEBOOK_SECRET_KEY=fb_secret_key
     depends_on:
       - postgres-db
 
   postgres-db:
     image: postgres:13-alpine
     ports:
-     - 5432:5432
+      - 5432:5432
     volumes:
       - dev-db-data:/var/lib/postgresql/data
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   django-app:
     build:
       context: .
+      dockerfile: Dockerfile
       args:
         - DEV=true
     ports:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ drf-spectacular>=0.22.1,<0.23
 Pillow>=9.1.0,<9.2
 django-countries>=7.3.2,<7.4
 django-ckeditor>=6.5.1,<6.6
+requests==2.28.1


### PR DESCRIPTION
## 描述

NextAuth 經社群帳號認證後，需傳遞 google/facebook access token api 登入 Django User
並使用 Django token 來發 API

## 變更類型

- [x] 新功能（增加功能的非破壞性更改
- [x] 文檔更新

## 這是如何測試的?

- [x] 請先用社群帳號登入後 (這邊我搭配 django-allauth 做登入並在 console print access token)，印出 access token，再用 postman 發。

## 檢查清單:

- [x] 我對文件做了相對應的修改
- [x] 我檢查了我的程式碼並更正了所有拼寫錯誤
